### PR TITLE
feat: add sns and sqs

### DIFF
--- a/import-service/.prettierrc.json
+++ b/import-service/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "trailingComma": "all",
   "singleQuote": true,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "printWidth": 120
 }

--- a/import-service/openapi.yml
+++ b/import-service/openapi.yml
@@ -32,7 +32,7 @@ paths:
                 type: string
               examples:
                 example1:
-                  value: "https://uploaded-products.s3.eu-central-1.amazonaws.com/uploaded/name?otherParams"
+                  value: 'https://uploaded-products.s3.eu-central-1.amazonaws.com/uploaded/name?otherParams'
         '500':
           description: Error during import
           content:

--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -19,10 +19,12 @@ const serverlessConfiguration: AWS = {
       {
         Effect: 'Allow',
         Action: ['s3:*'],
-        Resource: [
-          'arn:aws:s3:::${self:custom.bucketName}',
-          'arn:aws:s3:::${self:custom.bucketName}/*',
-        ],
+        Resource: ['arn:aws:s3:::${self:custom.bucketName}', 'arn:aws:s3:::${self:custom.bucketName}/*'],
+      },
+      {
+        Effect: 'Allow',
+        Action: ['sqs:SendMessage'],
+        Resource: ['arn:aws:sqs:eu-central-1:471767202967:products-queue'],
       },
     ],
     apiGateway: {

--- a/import-service/src/functions/importProductsFile/handler.test.ts
+++ b/import-service/src/functions/importProductsFile/handler.test.ts
@@ -2,10 +2,7 @@ import { importProductsFile } from './handler';
 
 jest.mock('aws-sdk', () => {
   const mockedS3 = {
-    getSignedUrlPromise: jest
-      .fn()
-      .mockReturnValueOnce('https://example.com')
-      .mockRejectedValueOnce(new Error('Error')),
+    getSignedUrlPromise: jest.fn().mockReturnValueOnce('https://example.com').mockRejectedValueOnce(new Error('Error')),
   };
 
   return {

--- a/import-service/src/functions/importProductsFile/handler.ts
+++ b/import-service/src/functions/importProductsFile/handler.ts
@@ -1,6 +1,5 @@
 import { formatJSONResponse, formatJSONResponseError } from '@libs/api-gateway';
 import { S3 } from 'aws-sdk';
-import * as console from 'console';
 
 export const importProductsFile = async event => {
   try {

--- a/import-service/src/libs/api-gateway.ts
+++ b/import-service/src/libs/api-gateway.ts
@@ -9,10 +9,7 @@ export const formatJSONResponse = (response, statusCode = 200) => {
   };
 };
 
-export const formatJSONResponseError = (
-  response: Record<string, unknown>,
-  statusCode = 500,
-) => {
+export const formatJSONResponseError = (response: Record<string, unknown>, statusCode = 500) => {
   return {
     headers: {
       'Access-Control-Allow-Origin': '*',

--- a/import-service/tsconfig.json
+++ b/import-service/tsconfig.json
@@ -12,13 +12,7 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*.ts", "serverless.ts"],
-  "exclude": [
-    "node_modules/**/*",
-    ".serverless/**/*",
-    ".webpack/**/*",
-    "_warmup/**/*",
-    ".vscode/**/*"
-  ],
+  "exclude": ["node_modules/**/*", ".serverless/**/*", ".webpack/**/*", "_warmup/**/*", ".vscode/**/*"],
   "ts-node": {
     "require": ["tsconfig-paths/register"]
   }

--- a/product-service/.prettierrc.json
+++ b/product-service/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "trailingComma": "all",
   "singleQuote": true,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "printWidth": 120
 }

--- a/product-service/src/functions/catalogBatchProcess/handler.test.ts
+++ b/product-service/src/functions/catalogBatchProcess/handler.test.ts
@@ -1,0 +1,66 @@
+import { catalogBatchProcess } from './handler';
+
+const product = {
+  title: 'Test Product',
+  description: 'This is a test product',
+  price: 9.99,
+  count: 10,
+};
+
+jest.mock('../../shared/db/db-products.service', () => {
+  const product = {
+    title: 'Test Product',
+    description: 'This is a test product',
+    price: 9.99,
+    count: 10,
+  };
+
+  const mockedDB = {
+    createProduct: jest
+      .fn()
+      .mockResolvedValueOnce({ ...product, id: 'id' })
+      .mockRejectedValueOnce(new Error('Error')),
+  };
+
+  return {
+    DbProductsService: jest.fn(() => mockedDB),
+  };
+});
+
+jest.mock('aws-sdk', () => {
+  const mockedSNS = {
+    publish: () => ({ promise: () => {} }),
+  };
+
+  return {
+    SNS: jest.fn(() => mockedSNS),
+  };
+});
+
+describe('catalogBatchProcess', () => {
+  it('should create products and publish messages', async () => {
+    const consoleSpy = jest.spyOn(console, 'log');
+    const event = {
+      Records: [
+        {
+          body: JSON.stringify(product),
+        },
+      ],
+    };
+    await catalogBatchProcess(event);
+    expect(consoleSpy).toHaveBeenCalledWith('Products successfully created');
+  });
+
+  it('should not product create because of validation issue', async () => {
+    const consoleSpy = jest.spyOn(console, 'log');
+    const event = {
+      Records: [
+        {
+          body: JSON.stringify({ ...product, title: null }),
+        },
+      ],
+    };
+    await catalogBatchProcess(event);
+    expect(consoleSpy).toHaveBeenCalledWith('Error:', { ...product, title: null }, 'Title is required');
+  });
+});

--- a/product-service/src/functions/catalogBatchProcess/handler.ts
+++ b/product-service/src/functions/catalogBatchProcess/handler.ts
@@ -1,0 +1,45 @@
+import { DbProductsService } from '../../shared/db/db-products.service';
+import { validateProduct } from '../../shared/helpers/product-validator';
+import { Product } from '../../shared/model/product';
+import { v4 } from 'uuid';
+import { SNS } from 'aws-sdk';
+
+const dbService = new DbProductsService();
+const sns = new SNS({ region: 'eu-central-1' });
+
+export const catalogBatchProcess = async event => {
+  try {
+    console.log('Event:', JSON.stringify(event));
+
+    for (const record of event.Records) {
+      const product: Product = JSON.parse(record.body);
+
+      const validationMessages = validateProduct(product);
+
+      if (validationMessages.length) {
+        console.log('Error:', product, validationMessages.join('; '));
+        return null;
+      }
+
+      product.id = v4();
+
+      await dbService.createProduct(product);
+
+      await sns
+        .publish({
+          Message: `New product was added: ${JSON.stringify(product, null, 2)}`,
+          TopicArn: process.env.CREATE_PRODUCT_TOPIC_ARN,
+          MessageAttributes: {
+            attributePrice: {
+              DataType: 'Number',
+              StringValue: String(product.price),
+            },
+          },
+        })
+        .promise();
+    }
+    console.log('Products successfully created');
+  } catch (e) {
+    console.log('Error:', e);
+  }
+};

--- a/product-service/src/functions/catalogBatchProcess/index.ts
+++ b/product-service/src/functions/catalogBatchProcess/index.ts
@@ -1,0 +1,15 @@
+import { handlerPath } from '@libs/handler-resolver';
+
+export default {
+  handler: `${handlerPath(__dirname)}/handler.catalogBatchProcess`,
+  events: [
+    {
+      sqs: {
+        arn: {
+          'Fn::GetAtt': ['catalogItemsQueue', 'Arn'],
+        },
+        batchSize: 5,
+      },
+    },
+  ],
+};

--- a/product-service/src/functions/createProduct/handler.ts
+++ b/product-service/src/functions/createProduct/handler.ts
@@ -6,19 +6,16 @@ import { v4 } from 'uuid';
 
 const dbService = new DbProductsService();
 
-export const createProduct = async (event) => {
+export const createProduct = async event => {
   try {
-    console.log('Event:', event)
+    console.log('Event:', event);
 
     const product: Product = JSON.parse(event.body);
 
     const validationMessages = validateProduct(product);
 
     if (validationMessages.length) {
-      return formatJSONResponseError(
-        { message: validationMessages.join('; ') },
-        400,
-      );
+      return formatJSONResponseError({ message: validationMessages.join('; ') }, 400);
     }
 
     product.id = v4();
@@ -33,7 +30,7 @@ export const createProduct = async (event) => {
       201,
     );
   } catch (e) {
-    console.log('Error:', e.message)
+    console.log('Error:', e.message);
 
     return formatJSONResponseError({
       message: e.message,

--- a/product-service/src/functions/getProductsById/handler.test.ts
+++ b/product-service/src/functions/getProductsById/handler.test.ts
@@ -39,10 +39,7 @@ describe('getProductsById', () => {
     });
     expect(response).toEqual(expectedResponse);
     expect(formatJSONResponse).not.toHaveBeenCalled();
-    expect(formatJSONResponseError).toHaveBeenCalledWith(
-      { message: errorMessage },
-      404,
-    );
+    expect(formatJSONResponseError).toHaveBeenCalledWith({ message: errorMessage }, 404);
   });
 
   it('should reject with an error message if an error occurs', async () => {
@@ -60,10 +57,7 @@ describe('getProductsById', () => {
     } catch (e) {
       expect(e).toEqual(expectedResponse);
       expect(formatJSONResponse).not.toHaveBeenCalled();
-      expect(formatJSONResponseError).toHaveBeenCalledWith(
-        { message: errorMessage },
-        500,
-      );
+      expect(formatJSONResponseError).toHaveBeenCalledWith({ message: errorMessage }, 500);
     }
     jest.restoreAllMocks();
   });

--- a/product-service/src/functions/getProductsById/handler.ts
+++ b/product-service/src/functions/getProductsById/handler.ts
@@ -3,9 +3,9 @@ import { DbProductsService } from '../../shared/db/db-products.service';
 
 const dbService = new DbProductsService();
 
-export const getProductsById = async (event) => {
+export const getProductsById = async event => {
   try {
-    console.log('Event:', event)
+    console.log('Event:', event);
 
     const productId = event?.pathParameters?.productId;
 
@@ -17,7 +17,7 @@ export const getProductsById = async (event) => {
 
     return formatJSONResponse(product);
   } catch (e) {
-    console.log('Error:', e.message)
+    console.log('Error:', e.message);
 
     return formatJSONResponseError({
       message: e.message,

--- a/product-service/src/functions/getProductsList/handler.test.ts
+++ b/product-service/src/functions/getProductsList/handler.test.ts
@@ -42,10 +42,7 @@ describe('getProductsList', () => {
     } catch (e) {
       expect(e).toEqual(expectedResponse);
       expect(formatJSONResponse).not.toHaveBeenCalled();
-      expect(formatJSONResponseError).toHaveBeenCalledWith(
-        { message: errorMessage },
-        500,
-      );
+      expect(formatJSONResponseError).toHaveBeenCalledWith({ message: errorMessage }, 500);
     }
     jest.restoreAllMocks();
   });

--- a/product-service/src/functions/getProductsList/handler.ts
+++ b/product-service/src/functions/getProductsList/handler.ts
@@ -3,15 +3,15 @@ import { DbProductsService } from '../../shared/db/db-products.service';
 
 const dbService = new DbProductsService();
 
-export const getProductsList = async (event) => {
+export const getProductsList = async event => {
   try {
-    console.log('Event:', event)
+    console.log('Event:', event);
 
     const products = await dbService.getProducts();
 
     return formatJSONResponse(products);
   } catch (e) {
-    console.log('Error:', e.message)
+    console.log('Error:', e.message);
 
     return formatJSONResponseError({
       message: e.message,

--- a/product-service/src/libs/api-gateway.ts
+++ b/product-service/src/libs/api-gateway.ts
@@ -9,10 +9,7 @@ export const formatJSONResponse = (response, statusCode = 200) => {
   };
 };
 
-export const formatJSONResponseError = (
-  response: Record<string, unknown>,
-  statusCode = 500,
-) => {
+export const formatJSONResponseError = (response: Record<string, unknown>, statusCode = 500) => {
   return {
     headers: {
       'Access-Control-Allow-Origin': '*',

--- a/product-service/src/shared/helpers/product-validator.ts
+++ b/product-service/src/shared/helpers/product-validator.ts
@@ -2,13 +2,13 @@ import { Product } from '../model/product';
 
 export const validateProduct = (product: Product): string[] => {
   const messages: string[] = [];
-  if (!isCountValid(product.count)) {
+  if (!isCountValid(+product.count)) {
     messages.push('Count should be non negative integer');
   }
   if (!product.title) {
     messages.push('Title is required');
   }
-  if (!isPriceValid(product.price)) {
+  if (!isPriceValid(+product.price)) {
     messages.push('Price should be positive number');
   }
   return messages;

--- a/product-service/tsconfig.json
+++ b/product-service/tsconfig.json
@@ -11,13 +11,7 @@
     "outDir": "lib"
   },
   "include": ["src/**/*.ts", "serverless.ts"],
-  "exclude": [
-    "node_modules/**/*",
-    ".serverless/**/*",
-    ".webpack/**/*",
-    "_warmup/**/*",
-    ".vscode/**/*"
-  ],
+  "exclude": ["node_modules/**/*", ".serverless/**/*", ".webpack/**/*", "_warmup/**/*", ".vscode/**/*"],
   "ts-node": {
     "require": ["tsconfig-paths/register"]
   }


### PR DESCRIPTION
Tasks 6.1, 6.2, 6.3, 6.4 are done.
Additional tasks are done:
- ```catalogBatchProcess``` lambda is covered by unit tests
- set a Filter Policy for SNS ```createProductTopic``` in ```serverless.yml``` and create an additional email subscription to distribute messages to different emails depending on the filter for any product attribute